### PR TITLE
Usability issue with the add control button.

### DIFF
--- a/help/examples/10-custom-controls.html
+++ b/help/examples/10-custom-controls.html
@@ -22,7 +22,8 @@
 			}
 		});
 
-		$("input[name=add]").click(function () {
+		$("input[name=add]").on("click.add",function () {
+			$(this).off("click.add");
 			$("textarea").wysiwyg("addControl", "quote", {
 				groupIndex: 2,
 				icon: './../tests/images/quote02.gif',


### PR DESCRIPTION
Upon adding a custom control, we should disable adding the same control again.

If unchecked, this bug leads to the callback being fired multiple times as it is registered every-time the button is clicked.